### PR TITLE
fix: autocast with dynamic device type for multi-platform support

### DIFF
--- a/vggt_inference/vggt_inference.py
+++ b/vggt_inference/vggt_inference.py
@@ -53,7 +53,7 @@ class VGGTInference(nn.Module):
         # Load and preprocess example images (replace with your own image paths)
         images = preprocess_images(input_images).to(self.device)
 
-        with torch.amp.autocast('cuda', dtype=self.dtype):
+        with torch.amp.autocast(self.device.type, dtype=self.dtype):
             images = images[None]  # add batch dimension
             aggregated_tokens_list, ps_idx = self.model.aggregator(images)
 


### PR DESCRIPTION
What changed: Replaced hardcoded 'cuda' with self.device.type in autocast context.

Why: Enables automatic device detection (MPS/CUDA/CPU) for mixed-precision casting, improving cross-platform compatibility.